### PR TITLE
Update oak version to 6.0.1 to use 0.60.1 deno std mod

### DIFF
--- a/applyGraphQL.ts
+++ b/applyGraphQL.ts
@@ -1,7 +1,7 @@
 import {
   Router,
   RouterContext,
-} from "https://deno.land/x/oak/mod.ts";
+} from "https://deno.land/x/oak@v6.0.1/mod.ts";
 import { graphql } from "./deps.ts";
 import { renderPlaygroundPage } from "./graphql-playground-html/render-playground-html.ts";
 import { makeExecutableSchema } from "./graphql-tools/schema/makeExecutableSchema.ts";


### PR DESCRIPTION
From deno 1.2.0 oak must be 6.0.1 as previous versions use deno std 0.60.0 which is not supported from 1.2.0